### PR TITLE
Fix artifact paths in the build CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,8 @@ jobs:
         with:
           name: ${{ github.sha }}
           path: |
-            *.class
-            *.jar
+            build/*.class
+            dependencies/*.jar
   Run_Basic_IO_Tests:
     needs: Build_Project
     runs-on: ubuntu-latest


### PR DESCRIPTION
Az elérési utak nem voltak a CI fájlokban a `master` állapotához igazítva.